### PR TITLE
cmake changes for libffi

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Build Macaulay2 using Ninja
         if: matrix.build-system == 'cmake'
         run: |
-          cmake --build . --target M2-core M2-emacs install-packages
+          cmake --build . --target M2-core M2-emacs M2-highlightjs install-packages
           if [[ "${{ runner.os }}" == "Linux" ]] && [[ "${{ matrix.compiler }}" == "clang-11" ]]; then
               sudo apt-get install -y -q --no-install-recommends dpkg-dev
               echo "GIT_COMMIT=`git describe --dirty --always --match HEAD`" >> $GITHUB_ENV

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           brew config
           brew tap macaulay2/tap
-          brew install autoconf automake bison boost tbb ccache cmake ctags gnu-tar libtool make ninja pkg-config yasm
+          brew install autoconf automake bison boost tbb ccache cmake ctags gnu-tar libtool make ninja pkg-config yasm libffi
           brew install --only-dependencies macaulay2/tap/M2
 
 # ----------------------
@@ -132,7 +132,7 @@ jobs:
         run: |
           cmake -S../.. -B. -GNinja \
             -DCMAKE_BUILD_TYPE=Release -DBUILD_NATIVE=OFF \
-            -DCMAKE_PREFIX_PATH="`brew --prefix`" \
+            -DCMAKE_PREFIX_PATH="`brew --prefix`;`brew --prefix libffi`" \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DWITH_PYTHON=ON \
             --debug-trycompile

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -280,6 +280,7 @@ The main targets for building Macaulay2 are:
 - `M2-binary`: build the Macaulay2 executable
 - `M2-core`: generate and copy the Core package
 - `M2-emacs`: generate the M2-mode package for Emacs
+- `M2-highlightjs`: generate syntax highlighting library for javascript
 
 In addition, the following targets are available:
 - `scc1`: build the Safe C Compiler

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -23,9 +23,9 @@ There are various tools needed to compile Macaulay2 dependencies.
 - On Mac OS X, using Homebrew, install `autoconf automake bison libtool pkg-config yasm`.
 
 There are 10 libraries that must be found on the system.
-- On Debian/Ubuntu, install `libopenblas-dev libgmp3-dev libxml2-dev libreadline-dev libgdbm-dev libboost-regex-dev libboost-stacktrace-dev libatomic-ops-dev libomp-dev libtbb-dev`.
-- On Fedora/CentOS, install `openblas-devel gmp-devel libxml2-devel readline-devel gdbm-devel boost-devel libatomic_ops-devel libomp-devel tbb-devel`.
-- On Mac OS X, using Homebrew, install `gmp libxml2 readline gdbm boost libatomic_ops libomp tbb`.
+- On Debian/Ubuntu, install `libopenblas-dev libgmp3-dev libxml2-dev libreadline-dev libgdbm-dev libboost-regex-dev libboost-stacktrace-dev libatomic-ops-dev libomp-dev libtbb-dev libffi-dev`.
+- On Fedora/CentOS, install `openblas-devel gmp-devel libxml2-devel readline-devel gdbm-devel boost-devel libatomic_ops-devel libomp-devel tbb-devel libffi-devel`.
+- On Mac OS X, using Homebrew, install `gmp libxml2 readline gdbm boost libatomic_ops libomp tbb libffi`.
 
 **TIP**: x86_64 binary packages for all dependencies on Mac OS X 10.15+ and Linux distributions are available through the [Macaulay2 tap](https://github.com/Macaulay2/homebrew-tap/) for Homebrew. To download the dependencies this way run:
 ```
@@ -150,6 +150,7 @@ For a complete list, along with descriptions, try `cmake -LAH .` or see `cmake/c
 - `USING_MPIR:BOOL=OFF`: use MPIR instead of GMP
 - `WITH_OMP:BOOL=ON`: link with the OpenMP library
 - `WITH_TBB:BOOL=ON`: link with the TBB library
+- `WITH_FFI:BOOL=ON`: link with the FFI library
 - `WITH_PYTHON:BOOL=OFF`: link with the Python library (set to `ON` to use the `Python` package)
 - `WITH_SQL:BOOL=OFF`: link with the MySQL library
 - `WITH_XML:BOOL=ON`: link with the libxml2 library

--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -87,6 +87,7 @@ set(DLIST
   interface.dd interface2.d
   texmacs.d
   boostmath.dd
+  ffi.d
   interp.dd	# this one is last, because it contains the top level interpreter
   version.dd
   )
@@ -140,7 +141,7 @@ add_library(M2-interpreter OBJECT ${CLIST} ${CXXLIST} ${TAGS}
   $<$<BOOL:${WITH_XML}>:xml-c.c xml-c.h>
   $<$<BOOL:${WITH_PYTHON}>:python-c.c>)
 
-target_link_libraries(M2-interpreter PRIVATE M2-supervisor Boost::regex TBB::tbb)
+target_link_libraries(M2-interpreter PRIVATE M2-supervisor Boost::regex TBB::tbb FFI::ffi)
 
 target_include_directories(M2-interpreter
   PUBLIC

--- a/M2/Macaulay2/editors/CMakeLists.txt
+++ b/M2/Macaulay2/editors/CMakeLists.txt
@@ -3,6 +3,7 @@
 ## and syntax highlighting engines as well as the M2-mode package for Emacs.
 ## - M2-editors generates grammar files
 ## - M2-emacs   generates the M2-mode package for Emacs
+## - M2-highlightjs   generates syntax highlighting library for javascript
 
 # TODO: generate vim grammar
 # TODO: generate textmate grammar
@@ -63,18 +64,20 @@ add_custom_command(OUTPUT ${EMACS_FILES}
 ################################################################################
 ## Generating highlight.js for syntax highlighting in the html documentation
 
-add_custom_target(M2-highlightjs ALL DEPENDS highlightjs/highlight.js)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/highlightjs)
-if(NOT NPM STREQUAL "NPM-NOTFOUND")
-  foreach(FILE IN ITEMS package.json webpack.config.js index.js
-      highlight-override.css)
-    configure_file(highlightjs/${FILE} highlightjs COPYONLY)
-  endforeach()
-  add_custom_command(OUTPUT highlightjs/highlight.js
-    COMMAND cd highlightjs && ${NPM} install && ${NPM} run build
-    DEPENDS highlightjs/macaulay2.js)
-else()
-  add_custom_command(OUTPUT highlightjs/highlight.js
-    COMMENT "warning: html docs will not have syntax highlighting"
-    COMMAND touch highlightjs/highlight.js)
+if(NOT NPM)
+  message(WARNING "npm is missing; html docs will not have syntax highlighting")
+  file(TOUCH highlightjs/highlight.js)
+  return()
 endif()
+
+set(HIGHLIGHTJS_DIR ${CMAKE_CURRENT_BINARY_DIR}/highlightjs)
+file(MAKE_DIRECTORY HIGHLIGHTJS_DIR)
+file(COPY highlightjs/ DESTINATION ${HIGHLIGHTJS_DIR}
+  FILES_MATCHING PATTERN "*.json" PATTERN "*.js" PATTERN "*.css")
+
+add_custom_target(M2-highlightjs ALL DEPENDS highlightjs/highlight.js)
+add_custom_command(OUTPUT highlightjs/highlight.js
+  COMMENT "Generating highlight.js syntax file"
+  COMMAND ${NPM} install && ${NPM} run build
+  WORKING_DIRECTORY ${HIGHLIGHTJS_DIR}
+  DEPENDS highlightjs/macaulay2.js)

--- a/M2/cmake/FindFFI.cmake
+++ b/M2/cmake/FindFFI.cmake
@@ -1,0 +1,81 @@
+# Attempts to discover ffi library with a linkable ffi_call function.
+#
+# Example usage:
+#
+# find_package(FFI)
+#
+# FFI_REQUIRE_INCLUDE may be set to consider ffi found if the includes
+# are present in addition to the library. This is useful to keep off
+# for the imported package on platforms that install the library but
+# not the headers.
+#
+# FFI_LIBRARY_DIR may be set to define search paths for the ffi library.
+#
+# If successful, the following variables will be defined:
+# FFI_FOUND
+# FFI_INCLUDE_DIRS
+# FFI_LIBRARIES
+# HAVE_FFI_CALL
+#
+# HAVE_FFI_H or HAVE_FFI_FFI_H is defined depending on the ffi.h include path.
+#
+# Additionally, the following import target will be defined:
+# FFI::ffi
+
+find_path(FFI_INCLUDE_DIRS ffi.h PATHS ${FFI_INCLUDE_DIR})
+if( EXISTS "${FFI_INCLUDE_DIRS}/ffi.h" )
+  set(FFI_HEADER ffi.h CACHE INTERNAL "")
+  set(HAVE_FFI_H 1 CACHE INTERNAL "")
+else()
+  find_path(FFI_INCLUDE_DIRS ffi/ffi.h PATHS ${FFI_INCLUDE_DIR})
+  if( EXISTS "${FFI_INCLUDE_DIRS}/ffi/ffi.h" )
+    set(FFI_HEADER ffi/ffi.h CACHE INTERNAL "")
+    set(HAVE_FFI_FFI_H 1 CACHE INTERNAL "")
+  endif()
+endif()
+
+find_library(FFI_LIBRARIES ffi PATHS ${FFI_LIBRARY_DIR})
+
+if(FFI_LIBRARIES)
+  include(CMakePushCheckState)
+  include(CheckCSourceCompiles)
+  cmake_push_check_state()
+  list(APPEND CMAKE_REQUIRED_LIBRARIES ${FFI_LIBRARIES})
+  check_c_source_compiles("
+    struct ffi_cif;
+    typedef struct ffi_cif ffi_cif;
+    void ffi_call(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue);
+    int main() { ffi_call(0, 0, 0, 0); }"
+    HAVE_FFI_CALL)
+  cmake_pop_check_state()
+endif()
+
+unset(required_includes)
+if(FFI_REQUIRE_INCLUDE)
+  set(required_includes FFI_INCLUDE_DIRS)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FFI
+                                  FOUND_VAR
+                                    FFI_FOUND
+                                  REQUIRED_VARS
+                                    FFI_LIBRARIES
+                                    ${required_includes}
+                                    HAVE_FFI_CALL)
+mark_as_advanced(FFI_LIBRARIES
+                 FFI_INCLUDE_DIRS
+                 HAVE_FFI_CALL
+                 FFI_HEADER
+                 HAVE_FFI_H
+                 HAVE_FFI_FFI_H)
+
+if(FFI_FOUND)
+  if(NOT TARGET FFI::ffi)
+    add_library(FFI::ffi UNKNOWN IMPORTED)
+    set_target_properties(FFI::ffi PROPERTIES IMPORTED_LOCATION "${FFI_LIBRARIES}")
+    if(FFI_INCLUDE_DIRS)
+      set_target_properties(FFI::ffi PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFI_INCLUDE_DIRS}")
+    endif()
+  endif()
+endif()

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -7,7 +7,7 @@
 ##    reconfigure NTL variables: cmake -U*NTL* .
 
 # These are some of the libraries linked with Macaulay2 in Macaulay2/{d,e,bin}/CMakeLists.txt
-# Others, like TBB::tbb and Boost::regex, are linked as imported libraries in those files.
+# Others, like TBB::tbb, FFI::ffi, and Boost::regex, are linked as imported libraries in those files.
 # TODO: turn all these libraries into imported libraries and find incompatibilities another way.
 set(PKGLIB_LIST    FFLAS_FFPACK GIVARO)
 set(LIBRARIES_LIST MPSOLVE FROBBY FACTORY FLINT NTL MPFI MPFR MP BDWGC LAPACK)
@@ -77,6 +77,10 @@ endforeach()
 
 if(WITH_TBB)
   find_package(TBB REQUIRED)
+endif()
+
+if(WITH_FFI)
+  find_package(FFI REQUIRED QUIET)
 endif()
 
 ###############################################################################

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -28,6 +28,7 @@ option(BUILD_DOCS	"Build internal documentation"		OFF)
 option(AUTOTUNE		"Autotune library parameters"		OFF)
 option(WITH_OMP		"Link with the OpenMP library"		ON)
 option(WITH_TBB		"Link with the TBB library"		ON)
+option(WITH_FFI		"Link with the FFI library"		ON)
 # TODO: parse.d expr.d tokens.d actors4.d actors5.d still need xml
 option(WITH_XML		"Link with the libxml2 library"		ON)
 # TODO: still not operational


### PR DESCRIPTION
Hope this helps!

If you decide to make linking with libffi optional, you can use `WITH_TBB` under cmake. I think only a couple of changes would need to be made in `d/CMakeLists.txt`

The tests seem to all be passing: https://github.com/mahrud/M2/runs/6858216514?check_suite_focus=true