### PR TITLE
Better Augmented Assignment in Mutable Hash Tables

### DIFF
--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1189,6 +1189,11 @@ globalAssignment(frameindex:int,t:Symbol,newvalue:Expr):Expr := ( -- frameID = 0
      vals.frameindex = newvalue;
      newvalue);
 
+assignment(nestingDepth:int,frameindex:int,t:Symbol,newvalue:Expr):Expr := (
+     if nestingDepth == -1
+     then globalAssignment(frameindex,t,newvalue)
+     else localAssignment(nestingDepth,frameindex,newvalue));
+
 globalAssignmentFun(x:globalAssignmentCode):Expr := (
      t := x.lhs;
      newvalue := eval(x.rhs);
@@ -1403,75 +1408,10 @@ augmentedParallelAssignmentFun(oper:Symbol, lhs:CodeSequence, rhs:Code):Expr:= (
 
 HashTableOrNull := HashTable or null;
 
--- check if code is x#k or x.k (where x is a hash table)
--- if so, lock it and return (so we can unlock it later)
-maybeLock(c:Code):HashTableOrNull := (
-    when c
-    is x:binaryCode do (
-	if x.oper == DotS.symbol || x.oper == SharpS.symbol
-	then (
-	    y := eval(x.lhs);
-	    when y is z:HashTable do (
-		if !z.beingInitialized then lockWrite(z.mutex);
-		HashTableOrNull(z))
-	    else HashTableOrNull(null()))
-	else HashTableOrNull(null()))
-    else HashTableOrNull(null()));
-
 maybeUnlock(x:HashTableOrNull):void := (
     when x
-    is y:HashTable do (
-	if !y.beingInitialized then unlock(y.mutex))
+    is y:HashTable do unlockHashTable(y)
     else nothing);
-
---what about mutable lists?
---assumes that the table has been locked on
-hashTableAugmentedAssignmentFun(lhs:binaryCode, oper1: Symbol, oper:Symbol, rexpr:Expr, rpos:Position):Expr := (
-    lexpr := nullE;
-    key := nullE;
-    table := eval(lhs.lhs);
-    when table
-    is Error do return table
-    is hashTable:HashTable do (
-        if lhs.oper == DotS.symbol then (
-            --this replicates dotfun from actors5.d but using the non-locking variation of lookup1force
-            when lhs.rhs
-            is r:globalSymbolClosureCode do (
-                key = Expr(SymbolClosure(globalFrame,r.symbol));
-                lexpr = lookup1forceNoLock(hashTable, key))
-            else nothing) --TODO correct error message printErrorMessageE(rhs,"expected a symbol"))
-        else if lhs.oper == SharpS.symbol then (
-            --TODO
-            key = eval(lhs.rhs);
-            lexpr = lookup1forceNoLock(hashTable, key)
-        )
-        else (
-            --this case should be impossible
-            return nullE;
-        );
-        meth := lookup(Class(lexpr), Expr(SymbolClosure(globalFrame, oper1)));
-        if meth != nullE then (
-            r := applyEEE(meth,lexpr,rexpr);--TODO what if meth tries to assign to the same hash table
-            --check if the returned value is the symbol "Default"
-	    when r
-            is s:SymbolClosure do (
-       	        if (s.symbol.word.name === "Default") then nothing
-	        else (
-                    return r
-                )
-            )
-            else (
-	        return r;
-	    )
-        );
-        left := evaluatedCode(lexpr, codePosition(Code(lhs)));
-        right := evaluatedCode(rexpr, rpos);
-        r := eval(Code(binaryCode(oper, Code(left), right, rpos)));
-        --r := oper.binary(Code(left),Code(right));
-        storeInHashTableNoLock(hashTable,key,hash(key),r);
-        r)
-    else WrongArgHashTable(1)
-    );
 
 augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
     when lookup(x.oper.word, augmentedAssignmentOperatorTable)
@@ -1488,61 +1428,47 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 	is y:angleBarListCode do (
 	    return augmentedParallelAssignmentFun(x.oper, y.t, x.rhs))
 	else nothing;
-	-- check if we're modifying a hash table and lock if so
-	table := maybeLock(x.lhs);
 	-- evaluate the left-hand side first
 	lexpr := nullE;
-	-- this will eventually hold the value to assign
+        -- if there's a table for the left hand side, it's stored here
+        table:HashTableOrNull := null();
+        key := nullE;
+        --TODO do we need to special case how this works with hash tables???
 	if s.word.name === "??" -- x ??= y is treated like x ?? (x = y)
 	then (
-	    maybeUnlock(table);
 	    e := nullify(x.lhs);
 	    when e
-	    is Nothing do (
-		return when x.lhs
-		is y:globalMemoryReferenceCode do (
-		    r := eval(x.rhs);
-		    when r is e:Error do r
-		    else globalAssignment(y.var.frameindex, y.var, r))
-		is y:localMemoryReferenceCode do (
-		    r := eval(x.rhs);
-		    when r is e:Error do r
-		    else localAssignment(y.nestingDepth, y.frameindex, r))
-		is y:threadMemoryReferenceCode do (
-		    r := eval(x.rhs);
-		    when r is e:Error do r
-		    else globalAssignment(y.var.frameindex, y.var, r))
-		is y:binaryCode do (
-		    r := x.rhs;
-		    if y.oper == DotS.symbol || y.oper == SharpS.symbol
-		    then (
-			z := AssignElemFun(y.lhs, y.rhs, r);
-			z)
-		    else InstallValueFun(CodeSequence(
-			    convertGlobalOperator(y.oper), y.lhs, y.rhs, r)))
-		is y:adjacentCode do (
-		    r := x.rhs;
-		    InstallValueFun(CodeSequence(
-			    convertGlobalOperator(AdjacentS.symbol), y.lhs, y.rhs, r)))
-		is y:unaryCode do (
-		    r := x.rhs;
-		    UnaryInstallValueFun(convertGlobalOperator(y.oper), y.rhs, r))
-		else buildErrorPacket(
-		    "augmented assignment not implemented for this code")
-		)
-	    else (
-		return e))
+	    is Nothing do nothing
+	    else return e)
 	else (
-            when table is hashTable:HashTable do (
-                when x.lhs is y:binaryCode do (
-                    r := hashTableAugmentedAssignmentFun(y, x.oper, s, eval(x.rhs), codePosition(x.rhs));
-	            unlock(hashTable.mutex);
-	            return r)
-                else nothing; --this case should be impossible
-                )
-            else nothing;
-            lexpr = eval(x.lhs)
-            );
+            --check if we are assiging to a lookup into something
+            when x.lhs is
+            y:binaryCode do(
+                if y.oper == DotS.symbol || y.oper == SharpS.symbol
+	        then (
+                    target := eval(y.lhs);
+                    when target
+                    is targetTable:HashTable do (
+                       table = targetTable;
+                       if y.oper == DotS.symbol then (
+                           --this replicates dotfun from actors5.d but using the special version of lookup
+                           when y.rhs
+                           is r:globalSymbolClosureCode do (
+                               key = Expr(SymbolClosure(globalFrame,r.symbol));
+                               lexpr = lookupAndLockHashTable(targetTable,key))
+                           else lexpr = printErrorMessageE(y.rhs,"expected a symbol")) -- using printErrorMessageE to replicate what dotfun in actors5.d does
+                       else if y.oper == SharpS.symbol then (
+                           key = eval(y.rhs);
+                           lexpr = lookupAndLockHashTable(targetTable,key))
+                       else (
+                           --This case should be impossible
+                           error("internal error: invalid augmented assignment operator");))
+                    else
+                        lexpr = eval(x.lhs)) --TODO we shouldn't be reevaluating the y.lhs
+                else
+                    lexpr = eval(x.lhs))
+            else
+                lexpr = eval(x.lhs));
 	when lexpr is e:Error do (
 	    return lexpr)
 	else nothing;
@@ -1559,8 +1485,10 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 	    is s:SymbolClosure do (
 		if s.symbol.word.name === "Default" then nothing
 		else (
+                    maybeUnlock(table);
 		    return r))
 	    else (
+                maybeUnlock(table);
 		return r));
 	-- if not, use default behavior
 	c := (
@@ -1584,8 +1512,14 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 	is y:binaryCode do (
 	    if y.oper == DotS.symbol || y.oper == SharpS.symbol
 	    then (
-		z := AssignElemFun(y.lhs, y.rhs, c);
-		z)
+                when table
+                is hashTable:HashTable do (
+                    r := eval(c);
+                    when r is Error do r
+                    else updateAndUnlockHashTable(hashTable,key,r))
+                else (
+		    z := AssignElemFun(y.lhs, y.rhs, c);
+		    z))
 	    else InstallValueFun(CodeSequence(
 		    convertGlobalOperator(y.oper), y.lhs, y.rhs, c)))
 	is y:adjacentCode do (

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1433,6 +1433,8 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
         -- if there's a table for the left hand side, it's stored here
         table:HashTableOrNull := null();
         key := nullE;
+        --if we encoute a hash table and need to lock, we should evaluate the right hand side first
+        rexpr := nullE;
         --TODO do we need to special case how this works with hash tables???
 	if s.word.name === "??" -- x ??= y is treated like x ?? (x = y)
 	then (
@@ -1450,6 +1452,9 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
                     when target
                     is targetTable:HashTable do (
                        table = targetTable;
+                       rexpr = eval(x.rhs);
+                       when rexpr is e:Error do return rexpr
+                       else nothing;
                        if y.oper == DotS.symbol then (
                            --this replicates dotfun from actors5.d but using the special version of lookup
                            when y.rhs
@@ -1475,7 +1480,7 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 	-- check if user-defined method exists
 	meth := lookup(Class(lexpr), Expr(SymbolClosure(globalFrame, x.oper)));
 	if meth != nullE then (
-	    rexpr := eval(x.rhs);
+	    if table==null() then rexpr = eval(x.rhs); --if table isn't null then rexpr is already valid, although it might be nullE still
 	    when rexpr is e:Error do (
 		maybeUnlock(table);
 		return rexpr)
@@ -1492,10 +1497,11 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 		return r));
 	-- if not, use default behavior
 	c := (
-	    if s.word.name === "??" then x.rhs
+            rcode := if table == null() then x.rhs else Code(evaluatedCode(rexpr, codePosition(x.rhs)));
+	    if s.word.name === "??" then rcode
 	    else Code(binaryCode(s,
 		    Code(evaluatedCode(lexpr, codePosition(x.lhs))),
-		    x.rhs, x.position)));
+		    rcode, x.position)));
 	when x.lhs
 	is y:globalMemoryReferenceCode do (
 	    r := eval(c);

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1429,13 +1429,12 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 	    return augmentedParallelAssignmentFun(x.oper, y.t, x.rhs))
 	else nothing;
 	-- evaluate the left-hand side first
-	lexpr := nullE;
+	lexpr := dummyExpr;
         -- if there's a table for the left hand side, it's stored here
         table:HashTableOrNull := null();
-        key := nullE;
+        key := dummyExpr;
         --if we encoute a hash table and need to lock, we should evaluate the right hand side first
-        rexpr := nullE;
-        --TODO do we need to special case how this works with hash tables???
+        rexpr := dummyExpr;
 	if s.word.name === "??" -- x ??= y is treated like x ?? (x = y)
 	then (
 	    e := nullify(x.lhs);
@@ -1482,7 +1481,7 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 	-- check if user-defined method exists
 	meth := lookup(Class(lexpr), Expr(SymbolClosure(globalFrame, x.oper)));
 	if meth != nullE then (
-	    if table==null() then rexpr = eval(x.rhs); --if table isn't null then rexpr is already valid, although it might be nullE still
+	    if rexpr == dummyExpr then rexpr = eval(x.rhs);
 	    when rexpr is e:Error do (
 		maybeUnlock(table);
 		return rexpr)
@@ -1499,7 +1498,7 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 		return r));
 	-- if not, use default behavior
 	c := (
-            rcode := if table == null() then x.rhs else Code(evaluatedCode(rexpr, codePosition(x.rhs)));
+            rcode := if rexpr == dummyExpr then x.rhs else Code(evaluatedCode(rexpr, codePosition(x.rhs)));
 	    if s.word.name === "??" then rcode
 	    else Code(binaryCode(s,
 		    Code(evaluatedCode(lexpr, codePosition(x.lhs))),

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1468,8 +1468,10 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
                        else (
                            --This case should be impossible
                            error("internal error: invalid augmented assignment operator");))
-                    else
-                        lexpr = eval(x.lhs)) --TODO we shouldn't be reevaluating the y.lhs
+                    else (
+                        --reconstruct the binary code with the already evaluated y.lhs
+                        targetCode := Code(evaluatedCode(target, codePosition(y.lhs)));
+                        lexpr = eval(Code(binaryCode(y.oper,targetCode,y.rhs,y.position)))))
                 else
                     lexpr = eval(x.lhs))
             else

--- a/M2/Macaulay2/d/hashtables.dd
+++ b/M2/Macaulay2/d/hashtables.dd
@@ -117,37 +117,6 @@ export remove(x:HashTable,key:Expr):Expr := (
      if !x.beingInitialized then unlock(x.mutex);
      ret);
 
-export storeInHashTableNoLock(x:HashTable,key:Expr,h:hash_t,value:Expr):Expr := (
-     if !x.Mutable then return buildErrorPacket("attempted to modify an immutable hash table");
-     hmod := int(h & (length(x.table)-1));
-     p := x.table.hmod;
-     while p != p.next do (
-	  if p.key == key || equal(p.key,key)==True 
-	  then (
-	       p.value = value;
-	       if !x.beingInitialized then unlock(x.mutex);
-	       return value);
-	  p = p.next);
-     if 4 * x.numEntries == 3 * length(x.table) -- SEE ABOVE
-     then (
-	  enlarge(x);
-	  hmod = int(h & (length(x.table)-1));
-	  );
-     -- Old comments:
-     -- In the following statement, a new entry is adding by atomically replacing the pointer x.table.hmod.
-     -- This will not confuse readers that don't lock the hash table, because once the load x.table.hmod, they
-     -- will have a linked list that stays the same, is shortened, or has a value changed, and contains no
-     -- duplicate entries.  Adding a new entry by appending to the end of the list, on the other hand, might
-     -- cause a reader to encounter the same key twice, if the key is removed and added while the reader is
-     -- traversing the list.
-     x.table.hmod = KeyValuePair(key,h,value,x.table.hmod);
-     --Do not increment numEntries until after new value pair has been inserted to maintain consistency.
-     --It is necessary to throw in a compilerBarrier to ensure that there is no memory reordering
-     -- compilerBarrier();
-     x.numEntries = x.numEntries + 1;
-     --Note: x.numEntries may be inconsistent with the number of entries in the table if accessed from another thread
-     value);
-
 export storeInHashTable(x:HashTable,key:Expr,h:hash_t,value:Expr):Expr := (
      if !x.Mutable then return buildErrorPacket("attempted to modify an immutable hash table");
      if !x.beingInitialized then lockWrite(x.mutex);
@@ -255,6 +224,7 @@ export storeInHashTableWithCollisionHandler(x:HashTable,key:Expr,value:Expr,hand
      x.numEntries = x.numEntries + 1;
      if !x.beingInitialized then unlock(x.mutex);
      value);
+
 toHashTableError(i:int):Expr := buildErrorPacket("expected element at position "+tostring(i)+" to be a pair");
 toHashTableWithCollisionHandler(v:Sequence,handler:Expr):Expr := (
      o := newHashTable(hashTableClass,nothingClass);
@@ -380,22 +350,6 @@ KeyNotFound(object:string, key:Expr):Expr := (
 	    msg = msg + ":\n" + info));
     buildErrorPacket(msg));
 
---Don't lock the table, used for augmented assignments
-export lookup1forceNoLock(object:HashTable, key:Expr, keyhash:hash_t):Expr := (
-     res := notfoundE;
-     keymod := int(keyhash & (length(object.table)-1));
-     bucket := object.table.keymod;
-     while bucket != bucket.next do (
-	  if bucket.key == key || bucket.hash == keyhash && equal(bucket.key,key)==True then (
-	       res = bucket.value;
-	       break);
-	  bucket = bucket.next;
-	  );
-     if res != notfoundE then res
-     else KeyNotFound("hash table", key)
-);
-export lookup1forceNoLock(object:HashTable, key:Expr):Expr := lookup1forceNoLock(object,key,hash(key));
-
 export lookup1(object:HashTable,key:Expr,keyhash:hash_t):Expr := (
      -- warning: can return notfoundE, which should not be given to the user
      res := notfoundE;
@@ -438,6 +392,45 @@ export lookup(object:HashTable,key:Expr):Expr := lookup(object,key,hash(key));
 export lookup(object:HashTable,key:SymbolClosure):Expr := (
      lookup(object,Expr(key),key.symbol.hash)
      );
+
+-----------------------------------------------------------------------------
+-- lookup and modify functions for augmented assignment operations
+
+-- This finds a single entry and locks the hash table for write, returning with the lock held
+-- This should be paired with updateAndUnlockHashTable or a call to unlockHashTable
+-- If the key isn't found, the table will be unlocked and a error returned
+export lookupAndLockHashTable(x:HashTable, key:Expr):Expr := (
+    h := hash(key);
+    if !x.beingInitialized then lockWrite(x.mutex);
+    hmod := int(h & (length(x.table)-1));
+    p := x.table.hmod;
+    while p != p.next do (
+        if p.key == key || equal(p.key,key)==True
+        then (
+            return p.value);
+        p = p.next);
+    unlock(x.mutex);
+    KeyNotFound("hash table", key));
+
+-- This must be called with the write lock held, it's intended to be the other half of lookupAndLockHashTable
+export updateAndUnlockHashTable(x:HashTable, key:Expr, value:Expr):Expr := (
+    if !x.Mutable then (
+        if !x.beingInitialized then unlock(x.mutex);
+        return buildErrorPacket("attempted to modify an immutable hash table"));
+    h := hash(key);
+    hmod := int(h & (length(x.table)-1));
+    p := x.table.hmod;
+    while p != p.next do (
+        if p.key == key || equal(p.key,key)==True
+        then (
+            p.value = value;
+            if !x.beingInitialized then unlock(x.mutex);
+            return value);
+        p = p.next);
+    if !x.beingInitialized then unlock(x.mutex);
+    KeyNotFound("hash table", key));
+
+export unlockHashTable(x:HashTable):void := if !x.beingInitialized then unlock(x.mutex);
 
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This changes how the augmented assignment works for hash tables so that the code is cleaner and there isn't as much duplication of the code. Unfortunately, there's some complicated merge conflicts with the parallel assignment changes, so some work is required before it can be merged.

I don't have the mental capacity at this moment to do this merge, so for now I've just added this pull request as is.